### PR TITLE
Remove sbt-scala3-migrate which implicilly sets `-source:3.0-migration`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,9 +21,6 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("dev.quadstingray" %% "sbt-json" % "0.7.1")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.7.2")
-
-
 addDependencyTreePlugin
 
 // todo remove as soon as possible

--- a/src/test/scala/dev/mongocamp/driver/mongodb/DocumentIncludesSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/DocumentIncludesSuite.scala
@@ -6,6 +6,7 @@ import munit.FunSuite
 import org.apache.lucene.search.MatchAllDocsQuery
 import org.bson.types.ObjectId
 import org.mongodb.scala.Document
+import org.mongodb.scala.documentToUntypedDocument
 
 class DocumentIncludesSuite extends FunSuite with DocumentIncludes {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/bson/ConverterSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/bson/ConverterSuite.scala
@@ -2,6 +2,7 @@ package dev.mongocamp.driver.mongodb.bson
 
 import dev.mongocamp.driver.mongodb.model.Base
 import dev.mongocamp.driver.mongodb.Converter
+import org.mongodb.scala.documentToUntypedDocument
 
 class ConverterSuite extends munit.FunSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/database/DatabaseProviderSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/database/DatabaseProviderSuite.scala
@@ -6,6 +6,7 @@ import dev.mongocamp.driver.mongodb._
 import dev.mongocamp.driver.mongodb.dao.BasePersonSuite
 import dev.mongocamp.driver.mongodb.test.TestDatabase._
 import org.mongodb.scala.Document
+import org.mongodb.scala.documentToUntypedDocument
 
 class DatabaseProviderSuite extends BasePersonSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/sql/DeleteSqlSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/sql/DeleteSqlSuite.scala
@@ -6,6 +6,7 @@ import dev.mongocamp.driver.mongodb.test.TestDatabase
 import dev.mongocamp.driver.mongodb.test.UniversityDatabase.GradeDAO
 import dev.mongocamp.driver.mongodb.GenericObservable
 import org.bson.types.ObjectId
+import org.mongodb.scala.documentToUntypedDocument
 
 class DeleteSqlSuite extends munit.FunSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/sql/InsertSqlSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/sql/InsertSqlSuite.scala
@@ -3,6 +3,7 @@ package dev.mongocamp.driver.mongodb.sql
 import dev.mongocamp.driver.mongodb.dao.BasePersonSuite
 import dev.mongocamp.driver.mongodb.test.TestDatabase
 import dev.mongocamp.driver.mongodb.GenericObservable
+import org.mongodb.scala.documentToUntypedDocument
 
 class InsertSqlSuite extends BasePersonSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/sql/OtherSqlSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/sql/OtherSqlSuite.scala
@@ -10,6 +10,7 @@ import dev.mongocamp.driver.mongodb.test.UniversityDatabase.GradeDAO
 import java.sql.SQLException
 import org.bson.types.ObjectId
 import org.mongodb.scala.model.Sorts.ascending
+import org.mongodb.scala.documentToUntypedDocument
 
 class OtherSqlSuite extends BasePersonSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/sql/SelectSqlSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/sql/SelectSqlSuite.scala
@@ -4,6 +4,7 @@ import dev.mongocamp.driver.mongodb.dao.BasePersonSuite
 import dev.mongocamp.driver.mongodb.test.TestDatabase
 import dev.mongocamp.driver.mongodb.GenericObservable
 import org.mongodb.scala.bson.BsonDocument
+import org.mongodb.scala.documentToUntypedDocument
 
 class SelectSqlSuite extends BasePersonSuite {
 

--- a/src/test/scala/dev/mongocamp/driver/mongodb/sql/UpdateSqlSuite.scala
+++ b/src/test/scala/dev/mongocamp/driver/mongodb/sql/UpdateSqlSuite.scala
@@ -7,6 +7,7 @@ import dev.mongocamp.driver.mongodb.test.TestDatabase
 import dev.mongocamp.driver.mongodb.test.UniversityDatabase.GradeDAO
 import munit.FunSuite
 import org.bson.types.ObjectId
+import org.mongodb.scala.documentToUntypedDocument
 
 class UpdateSqlSuite extends FunSuite {
 


### PR DESCRIPTION
When using `sbt-scala3-migate` plugin it implicitlly adds `-source:3.0-migration` which mitigates some incompatibilites when migrating to Scala 3. One of these incompatibilites is search scope for implicit conversions - in Scala 2 the package of the declared type was also searched - this deprecated behaviour was used in the tests. 

- Add explicit imports for Document conversions
- Remove `sbt-scala3-migrate` plugin 

This issue was spotted when investigating failures for this project in https://github.com/VirtusLab/community-build3 for latest versions of the compiler